### PR TITLE
Fix davitpy by added necessary radar hardware files

### DIFF
--- a/resen-core/Dockerfile
+++ b/resen-core/Dockerfile
@@ -89,6 +89,11 @@ RUN /bin/bash -cl 'bash setup_cartopy.sh && rm setup_cartopy.sh'
 # install davitpy 0.8-master
 COPY resources/helpers/setup_davitpy.sh .
 RUN /bin/bash -cl 'bash setup_davitpy.sh && rm setup_davitpy.sh'
+# set davitpy environment variables
+ENV SD_HDWPATH=$HOME/cache/hdw.dat
+ENV SD_RADAR=$HOME/cache/radar.dat
+
+
 
 # install spacepy 0.1.6
 COPY resources/helpers/setup_spacepy.sh .

--- a/resen-core/resources/helpers/setup_davitpy.sh
+++ b/resen-core/resources/helpers/setup_davitpy.sh
@@ -23,6 +23,11 @@ git checkout tags/0.8-master -b 0.8-master
 conda activate py27
 LDFLAGS="-shared" pip install .
 
+# get hdw.dat and radar.dat - needed so davitpy can get radar information locally
+cd $HOME/cache
+git clone https://github.com/vtsuperdarn/hdw.dat.git
+wget https://raw.githubusercontent.com/SuperDARN/rst/master/tables/superdarn/radar.dat
+
 # cleanup
 cd $CWD
 rm -r $DAVITPY_BUILD_DIR


### PR DESCRIPTION
Because davitpy can't currently connect with the server, we need to have certain hardware and radar information files available locally.  This implements the proposed solution in https://github.com/vtsuperdarn/davitpy/issues/363#issuecomment-403857430.
1. Clone vtsuperdarn's `hdw.dat` repo.
2. Download `radar.dat` from SuperDARN/rst repo.
3. Set the environment variables `SD_HDWPATH` and `SD_RADAR` so davitpy can find these files.

The py27 test import scrip runs successfully now (solving #3) and I can run davitpy tutorial notebooks with resen.  The one part about this I'm not sure about is I had to set the environment variables in the Dockerfile not `setup_davitpy.sh`.  Are we ok with that approach?