### PR TITLE
[BUG]: install missing ncurses dev files

### DIFF
--- a/resen-core/Dockerfile
+++ b/resen-core/Dockerfile
@@ -34,7 +34,8 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     mlocate \
     less \
-    vim
+    vim \
+    libncurses5-dev
 
 # custom scripts
 COPY resources/start-singleuser-ingeo.sh /usr/local/bin


### PR DESCRIPTION
Since we will be moving towards removing conda from resen-core, I decided to fix #17 by installing `libncurses5-dev` using apt-get.

The PR fixes #17.