### PR TITLE
adding cartopy admin_1_states_provinces_lakes

### DIFF
--- a/resen-core/resources/feature_download.py
+++ b/resen-core/resources/feature_download.py
@@ -82,6 +82,7 @@ FEATURE_DEFN_GROUPS = {
         ('cultural', 'admin_0_pacific_groupings', '110m'),
         ('cultural', 'admin_1_states_provinces_shp', '110m'),
         ('cultural', 'admin_1_states_provinces_lines', '110m'),
+        ('cultural', 'admin_1_states_provinces_lakes', '110m'),
     ),
 }
 


### PR DESCRIPTION
@asreimer The mangopy tutorial triggers the download of admin_1_states_provinces_lakes, so adding this to have it already.