### PR TITLE
[ENH]: Add a Dockerfile for a base resen image

### DIFF
--- a/resen-base/Dockerfile
+++ b/resen-base/Dockerfile
@@ -72,7 +72,6 @@ RUN chmod +x /usr/local/bin/start.sh && \
 #stuff from jupyter/scipy-notebook
 RUN apt-get update && apt-get install -yq --no-install-recommends \
     build-essential \
-    emacs \
     git \
     jed \
     libsm6 \
@@ -89,8 +88,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     texlive-latex-extra \
     texlive-xetex \
     tzdata \
-    unzip \
-    nano && \
+    unzip && \
     rm -rf /var/lib/apt/lists/*
 
 USER $NB_USER

--- a/resen-base/Dockerfile
+++ b/resen-base/Dockerfile
@@ -1,0 +1,97 @@
+FROM ubuntu:18.04
+
+LABEL maintainer="Ingeo Team <ingeo-team@ingeo.datatransport.org>"
+LABEL description="The base docker image from which resen-core images are built."
+
+#--------------------------------------------------
+# First, make sure we have some of the things that
+# jupyter/scipy-notebook has in it
+#--------------------------------------------------
+# stuff from jupyter/base-notebook
+
+ARG NB_USER="jovyan"
+ARG NB_UID="1000"
+ARG NB_GID="100"
+
+USER root
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get -yq dist-upgrade && \
+    apt-get install -yq --no-install-recommends \
+    wget \
+    bzip2 \
+    ca-certificates \
+    sudo \
+    locales \
+    fonts-liberation \
+    run-one && \
+    rm -rf /var/lib/apt/lists/*
+
+# install tini
+ARG TINI_VERSION="v0.18.0"
+RUN cd /usr/local/bin && \
+    wget https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini && \
+    chmod +x /usr/local/bin/tini && \
+    rm /root/.wget-hsts
+
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
+    locale-gen
+
+# Add a script that we will use to correct permissions after running certain commands
+ADD resources/fix-permissions /usr/local/bin/fix-permissions
+RUN chmod +x /usr/local/bin/fix-permissions
+
+# Enable prompt color in the skeleton .bashrc before creating the default NB_USER
+RUN sed -i 's/^#force_color_prompt=yes/force_color_prompt=yes/' /etc/skel/.bashrc
+
+# Create NB_USER wtih name jovyan user with UID=1000 and in the 'users' group
+# and make sure these dirs are writable by the `users` group.
+RUN echo "auth requisite pam_deny.so" >> /etc/pam.d/su && \
+    sed -i.bak -e 's/^%admin/#%admin/' /etc/sudoers && \
+    sed -i.bak -e 's/^%sudo/#%sudo/' /etc/sudoers && \
+    useradd -m -s /bin/bash -N -u $NB_UID $NB_USER && \
+    chmod g+w /etc/passwd && \
+    fix-permissions $HOME
+
+# Configure container startup
+ENTRYPOINT ["tini", "-g", "--"]
+CMD ["start-notebook.sh"]
+
+# Set up system environment variables
+COPY resources/02-resen.sh /etc/profile.d/
+
+# Add scripts for starting servers
+COPY resources/start.sh /usr/local/bin/
+COPY resources/start-notebook.sh /usr/local/bin/
+COPY resources/start-singleuser.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/start.sh && \
+    chmod +x /usr/local/bin/start-notebook.sh && \
+    chmod +x /usr/local/bin/start-singleuser.sh
+
+
+#stuff from jupyter/scipy-notebook
+RUN apt-get update && apt-get install -yq --no-install-recommends \
+    build-essential \
+    emacs \
+    git \
+    jed \
+    libsm6 \
+    libxext-dev \
+    libxrender1 \
+    lmodern \
+    netcat \
+    pandoc \
+    python-dev \
+    texlive-fonts-extra \
+    texlive-fonts-recommended \
+    texlive-generic-recommended \
+    texlive-latex-base \
+    texlive-latex-extra \
+    texlive-xetex \
+    tzdata \
+    unzip \
+    nano && \
+    rm -rf /var/lib/apt/lists/*
+
+USER $NB_USER
+WORKDIR /home/$NB_USER

--- a/resen-base/resources/02-resen.sh
+++ b/resen-base/resources/02-resen.sh
@@ -1,0 +1,2 @@
+export SHELL=/bin/bash
+export LANG=C.UTF-8

--- a/resen-base/resources/fix-permissions
+++ b/resen-base/resources/fix-permissions
@@ -1,0 +1,35 @@
+#!/bin/bash
+# set permissions on a directory
+# after any installation, if a directory needs to be (human) user-writable,
+# run this script on it.
+# It will make everything in the directory owned by the group $NB_GID
+# and writable by that group.
+# Deployments that want to set a specific user id can preserve permissions
+# by adding the `--group-add users` line to `docker run`.
+
+# uses find to avoid touching files that already have the right permissions,
+# which would cause massive image explosion
+
+# right permissions are:
+# group=$NB_GID
+# AND permissions include group rwX (directory-execute)
+# AND directories have setuid,setgid bits set
+
+set -e
+
+for d in "$@"; do
+  find "$d" \
+    ! \( \
+      -group $NB_GID \
+      -a -perm -g+rwX  \
+    \) \
+    -exec chgrp $NB_GID {} \; \
+    -exec chmod g+rwX {} \;
+  # setuid,setgid *on directories only*
+  find "$d" \
+    \( \
+        -type d \
+        -a ! -perm -6000  \
+    \) \
+    -exec chmod +6000 {} \;
+done

--- a/resen-base/resources/start-notebook.sh
+++ b/resen-base/resources/start-notebook.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+set -e
+
+if [[ ! -z "${JUPYTERHUB_API_TOKEN}" ]]; then
+  # launched by JupyterHub, use single-user entrypoint
+  exec /usr/local/bin/start-singleuser.sh "$@"
+elif [[ ! -z "${JUPYTER_ENABLE_LAB}" ]]; then
+  . /usr/local/bin/start.sh jupyter lab "$@"
+else
+  . /usr/local/bin/start.sh jupyter notebook "$@"
+fi

--- a/resen-base/resources/start-singleuser.sh
+++ b/resen-base/resources/start-singleuser.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+set -e
+
+source /home/jovyan/envs/py36/bin/activate
+
+# set default ip to 0.0.0.0
+if [[ "$NOTEBOOK_ARGS $@" != *"--ip="* ]]; then
+  NOTEBOOK_ARGS="--ip=0.0.0.0 $NOTEBOOK_ARGS"
+fi
+
+# handle some deprecated environment variables
+# from DockerSpawner < 0.8.
+# These won't be passed from DockerSpawner 0.9,
+# so avoid specifying --arg=empty-string
+if [ ! -z "$NOTEBOOK_DIR" ]; then
+  NOTEBOOK_ARGS="--notebook-dir='$NOTEBOOK_DIR' $NOTEBOOK_ARGS"
+fi
+if [ ! -z "$JPY_PORT" ]; then
+  NOTEBOOK_ARGS="--port=$JPY_PORT $NOTEBOOK_ARGS"
+fi
+if [ ! -z "$JPY_USER" ]; then
+  NOTEBOOK_ARGS="--user=$JPY_USER $NOTEBOOK_ARGS"
+fi
+if [ ! -z "$JPY_COOKIE_NAME" ]; then
+  NOTEBOOK_ARGS="--cookie-name=$JPY_COOKIE_NAME $NOTEBOOK_ARGS"
+fi
+if [ ! -z "$JPY_BASE_URL" ]; then
+  NOTEBOOK_ARGS="--base-url=$JPY_BASE_URL $NOTEBOOK_ARGS"
+fi
+if [ ! -z "$JPY_HUB_PREFIX" ]; then
+  NOTEBOOK_ARGS="--hub-prefix=$JPY_HUB_PREFIX $NOTEBOOK_ARGS"
+fi
+if [ ! -z "$JPY_HUB_API_URL" ]; then
+  NOTEBOOK_ARGS="--hub-api-url=$JPY_HUB_API_URL $NOTEBOOK_ARGS"
+fi
+if [ ! -z "$JUPYTER_ENABLE_LAB" ]; then
+  NOTEBOOK_BIN="jupyter labhub"
+else
+  NOTEBOOK_BIN="jupyterhub-singleuser"
+fi
+
+. /usr/local/bin/start.sh $NOTEBOOK_BIN $NOTEBOOK_ARGS "$@"

--- a/resen-base/resources/start.sh
+++ b/resen-base/resources/start.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+set -e
+
+# Exec the specified command or fall back on bash
+if [ $# -eq 0 ]; then
+    cmd=( "bash" )
+else
+    cmd=( "$@" )
+fi
+
+run-hooks () {
+    # Source scripts or run executable files in a directory
+    if [[ ! -d "$1" ]] ; then
+        return
+    fi
+    echo "$0: running hooks in $1"
+    for f in "$1/"*; do
+        case "$f" in
+            *.sh)
+                echo "$0: running $f"
+                source "$f"
+                ;;
+            *)
+                if [[ -x "$f" ]] ; then
+                    echo "$0: running $f"
+                    "$f"
+                else
+                    echo "$0: ignoring $f"
+                fi
+                ;;
+        esac
+    done
+    echo "$0: done running hooks in $1"
+}
+
+run-hooks /usr/local/bin/start-notebook.d
+
+# Handle special flags if we're root
+if [ $(id -u) == 0 ] ; then
+
+    # Only attempt to change the jovyan username if it exists
+    if id jovyan &> /dev/null ; then
+        echo "Set username to: $NB_USER"
+        usermod -d /home/$NB_USER -l $NB_USER jovyan
+    fi
+
+    # Handle case where provisioned storage does not have the correct permissions by default
+    # Ex: default NFS/EFS (no auto-uid/gid)
+    if [[ "$CHOWN_HOME" == "1" || "$CHOWN_HOME" == 'yes' ]]; then
+        echo "Changing ownership of /home/$NB_USER to $NB_UID:$NB_GID with options '${CHOWN_HOME_OPTS}'"
+        chown $CHOWN_HOME_OPTS $NB_UID:$NB_GID /home/$NB_USER
+    fi
+    if [ ! -z "$CHOWN_EXTRA" ]; then
+        for extra_dir in $(echo $CHOWN_EXTRA | tr ',' ' '); do
+            echo "Changing ownership of ${extra_dir} to $NB_UID:$NB_GID with options '${CHOWN_EXTRA_OPTS}'"
+            chown $CHOWN_EXTRA_OPTS $NB_UID:$NB_GID $extra_dir
+        done
+    fi
+
+    # handle home and working directory if the username changed
+    if [[ "$NB_USER" != "jovyan" ]]; then
+        # changing username, make sure homedir exists
+        # (it could be mounted, and we shouldn't create it if it already exists)
+        if [[ ! -e "/home/$NB_USER" ]]; then
+            echo "Relocating home dir to /home/$NB_USER"
+            mv /home/jovyan "/home/$NB_USER"
+        fi
+        # if workdir is in /home/jovyan, cd to /home/$NB_USER
+        if [[ "$PWD/" == "/home/jovyan/"* ]]; then
+            newcwd="/home/$NB_USER/${PWD:13}"
+            echo "Setting CWD to $newcwd"
+            cd "$newcwd"
+        fi
+    fi
+
+    # Change UID of NB_USER to NB_UID if it does not match
+    if [ "$NB_UID" != $(id -u $NB_USER) ] ; then
+        echo "Set $NB_USER UID to: $NB_UID"
+        usermod -u $NB_UID $NB_USER
+    fi
+
+    # Set NB_USER primary gid to NB_GID (after making the group).  Set
+    # supplementary gids to NB_GID and 100.
+    if [ "$NB_GID" != $(id -g $NB_USER) ] ; then
+        echo "Add $NB_USER to group: $NB_GID"
+        groupadd -g $NB_GID -o ${NB_GROUP:-${NB_USER}}
+        usermod  -g $NB_GID -aG 100 $NB_USER
+    fi
+
+    # Enable sudo if requested
+    if [[ "$GRANT_SUDO" == "1" || "$GRANT_SUDO" == 'yes' ]]; then
+        # echo "Granting $NB_USER sudo access and appending $CONDA_DIR/bin to sudo PATH"
+        echo "Granting $NB_USER sudo access"
+        echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook
+    fi
+
+    # Add $CONDA_DIR/bin to sudo secure_path (not needed for resen-core)
+    #sed -r "s#Defaults\s+secure_path=\"([^\"]+)\"#Defaults secure_path=\"\1:$CONDA_DIR/bin\"#" /etc/sudoers | grep secure_path > /etc/sudoers.d/path
+
+    # Exec the command as NB_USER with the PATH and the rest of
+    # the environment preserved
+    run-hooks /usr/local/bin/before-notebook.d
+    echo "Executing the command: ${cmd[@]}"
+    exec sudo -E -H -u $NB_USER PATH=$PATH XDG_CACHE_HOME=/home/$NB_USER/.cache PYTHONPATH=${PYTHONPATH:-} "${cmd[@]}"
+else
+    if [[ "$NB_UID" == "$(id -u jovyan)" && "$NB_GID" == "$(id -g jovyan)" ]]; then
+        # User is not attempting to override user/group via environment
+        # variables, but they could still have overridden the uid/gid that
+        # container runs as. Check that the user has an entry in the passwd
+        # file and if not add an entry.
+        STATUS=0 && whoami &> /dev/null || STATUS=$? && true
+        if [[ "$STATUS" != "0" ]]; then
+            if [[ -w /etc/passwd ]]; then
+                echo "Adding passwd file entry for $(id -u)"
+                cat /etc/passwd | sed -e "s/^jovyan:/nayvoj:/" > /tmp/passwd
+                echo "jovyan:x:$(id -u):$(id -g):,,,:/home/jovyan:/bin/bash" >> /tmp/passwd
+                cat /tmp/passwd > /etc/passwd
+                rm /tmp/passwd
+            else
+                echo 'Container must be run with group "root" to update passwd file'
+            fi
+        fi
+
+        # Warn if the user isn't going to be able to write files to $HOME.
+        if [[ ! -w /home/jovyan ]]; then
+            echo 'Container must be run with group "users" to update files'
+        fi
+    else
+        # Warn if looks like user want to override uid/gid but hasn't
+        # run the container as root.
+        if [[ ! -z "$NB_UID" && "$NB_UID" != "$(id -u)" ]]; then
+            echo 'Container must be run as root to set $NB_UID'
+        fi
+        if [[ ! -z "$NB_GID" && "$NB_GID" != "$(id -g)" ]]; then
+            echo 'Container must be run as root to set $NB_GID'
+        fi
+    fi
+
+    # Warn if looks like user want to run in sudo mode but hasn't run
+    # the container as root.
+    if [[ "$GRANT_SUDO" == "1" || "$GRANT_SUDO" == 'yes' ]]; then
+        echo 'Container must be run as root to grant sudo permissions'
+    fi
+
+    # Execute the command
+    run-hooks /usr/local/bin/before-notebook.d
+    echo "Executing the command: ${cmd[@]}"
+    exec "${cmd[@]}"
+fi


### PR DESCRIPTION
It takes quite awhile for all of the apt-get stuff to run when building the resen-core Dockerfile. For development and testing purposes, this makes is take much longer when building from scratch.

In preparation for adding CI, I've created a resen-base Dockerfile that is intended to provide an image from which resen-cores can be based.

Thoughts? This PR is only intended to introduce a resen-base Dockerfile. A subsequent PR can modify the resen-core Dockerfile to use a resen-base image in dockerhub later.