### PR TITLE
[BUG]: Explicitly set shell and upgrade jupyterlab

### DIFF
--- a/resen-core/Dockerfile
+++ b/resen-core/Dockerfile
@@ -194,3 +194,8 @@ RUN /bin/bash -cl 'source /home/$NB_USER/envs/py36/bin/activate && \
 # Finally set up some stuff to make user experience better
 RUN echo "TERM=xterm-256color" >> /home/$NB_USER/.bashrc && \
     echo "MPLBACKEND=Agg" >> /home/$NB_USER/.bashrc
+
+# Set default jupyter terminal shell
+RUN /bin/bash -cl 'source /home/$NB_USER/envs/py36/bin/activate && \
+                   jupyter lab --generate-config'
+RUN sed -i -e 's/#c.NotebookApp.terminado_settings = {}/c.NotebookApp.terminado_settings = {\"shell_command\"\:[\"\/bin\/bash\"]}/' /home/jovyan/.jupyter/jupyter_notebook_config.py

--- a/resen-core/resources/helpers/setup_py36_env.sh
+++ b/resen-core/resources/helpers/setup_py36_env.sh
@@ -13,7 +13,7 @@ pip install pip==19.2.3
 # Now use pip to install everything we can
 # Notes: pyproj==1.9.6 required for basemap, 2.0.0 breaks basemap
 pip install -U jupyterhub==1.0.0 \
-               jupyterlab==0.35.6 \
+               jupyterlab==1.1.4 \
                notebook==6.0.1 \
                paramiko==2.4.2 \
                ipython==7.4.0 \


### PR DESCRIPTION
Jupyterlab doesn't always start terminal windows with bash, either when running resen-core locally or on the ingeo server.

To fix this, we set the shell explicitly in `~/.jupter/jupyter_notebook_config.py` and upgraded jupyterlab to 1.1.4.

Upgrading jupyterlab improves stability, provides more and better features, and integrates better when running on the ingeo server.