### PR TITLE
Adding nodejs and extension manager that allows %matplotlib widget and other third-party extensions

### DIFF
--- a/resen-core/Dockerfile
+++ b/resen-core/Dockerfile
@@ -109,7 +109,8 @@ RUN /bin/bash -cl 'source /home/$NB_USER/envs/py36/bin/activate && \
 
 # Installing jupyter-widgets
 RUN /bin/bash -cl 'source /home/$NB_USER/envs/py36/bin/activate && \
-                   pip install ipympl && \
+                   pip install ipympl==0.5.6 && \
+                   pip install hdfviewer==0.11.0 && \
                    jupyter labextension install @jupyter-widgets/jupyterlab-manager && \
                    jupyter labextension install jupyter-matplotlib'
 
@@ -123,3 +124,6 @@ RUN /bin/bash -cl 'source /home/$NB_USER/envs/py36/bin/activate && \
                    jupyter lab --generate-config'
 RUN sed -i -e 's/#c.NotebookApp.terminado_settings = {}/c.NotebookApp.terminado_settings = {\"shell_command\"\:[\"\/bin\/bash\"]}/' /home/jovyan/.jupyter/jupyter_notebook_config.py
 
+# Set the jupyterlab user-settings
+RUN /bin/bash -cl 'mkdir -p /home/jovyan/.jupyter/lab/user-settings/@jupyterlab/extensionmanager-extension && \
+                 echo  "{\"disclaimed\": false,\"enabled\":false}" > /home/jovyan/.jupyter/lab/user-settings/@jupyterlab/extensionmanager-extension/plugin.jupyterlab-settings'

--- a/resen-core/Dockerfile
+++ b/resen-core/Dockerfile
@@ -43,11 +43,17 @@ RUN apt-get update && \
     libncurses5-dev && \
     rm -rf /var/lib/apt/lists/*
 
+# Install nodejs and npm needed for matplotlib widgets
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
+    apt-get install -yq --no-install-recommends nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
 # Create python 2.7 and python 3.6 virtual environments
 USER $NB_USER
 RUN /bin/bash -c 'mkdir -p /home/$NB_USER/envs && \
         python3 -m virtualenv -p /usr/bin/python3.6 /home/$NB_USER/envs/py36 && \
         python3 -m virtualenv -p /usr/bin/python2.7 /home/$NB_USER/envs/py27'
+
 
 WORKDIR /home/$NB_USER
 
@@ -101,7 +107,14 @@ RUN /bin/bash -cl 'source /home/$NB_USER/envs/py36/bin/activate && \
                    python feature_download.py physical cultural cultural-extra --do_scales 110m && \
                    rm feature_download.py'
 
+# Installing jupyter-widgets
+RUN /bin/bash -cl 'source /home/$NB_USER/envs/py36/bin/activate && \
+                   pip install ipympl && \
+                   jupyter labextension install @jupyter-widgets/jupyterlab-manager && \
+                   jupyter labextension install jupyter-matplotlib'
+
 # Finally set up some stuff to make user experience better
+
 RUN echo "TERM=xterm-256color" >> /home/$NB_USER/.bashrc && \
     echo "MPLBACKEND=Agg" >> /home/$NB_USER/.bashrc
 
@@ -109,3 +122,4 @@ RUN echo "TERM=xterm-256color" >> /home/$NB_USER/.bashrc && \
 RUN /bin/bash -cl 'source /home/$NB_USER/envs/py36/bin/activate && \
                    jupyter lab --generate-config'
 RUN sed -i -e 's/#c.NotebookApp.terminado_settings = {}/c.NotebookApp.terminado_settings = {\"shell_command\"\:[\"\/bin\/bash\"]}/' /home/jovyan/.jupyter/jupyter_notebook_config.py
+


### PR DESCRIPTION
This pull request adds `nodejs` to` resen-core` (extra ~600MB) which allows `extension manager` to be installed. `extension manager` allows third-party extensions to be installed in `jupyter`. The pull request also adds the `jupyter-matplotlib` (per enhancement discussion: [resen-core#42](https://github.com/EarthCubeInGeo/resen-core/issues/42)) extension which offers zoom and scroll capabilities to 2D and 3D `matplotlib` plots. Interesting third-party extensions that users will be able to install on their own:

- [@jupyter-matplotlib](https://github.com/matplotlib/ipympl)  (already in the pull request per enhancement discussion: [resen-core#42](https://github.com/EarthCubeInGeo/resen-core/issues/42))
- [hdfviewer](https://pypi.org/project/hdfviewer)
- [jupyterlab-spreadsheet](https://github.com/quigleyj97/jupyterlab-spreadsheet#readme) (supports XLS, XLSX, and CSV files)
- [@jupyterlab/google-drive](https://www.npmjs.com/package/@jupyterlab/google-drive) This would allow to access google drive storage.
- [k3d](https://github.com/K3D-tools/K3D-jupyter#readme) (3D visualization library)
...