### PR TITLE
Moving ipympl to the py27 and py36 helpers

### DIFF
--- a/resen-core/Dockerfile
+++ b/resen-core/Dockerfile
@@ -112,8 +112,6 @@ RUN /bin/bash -cl 'source /home/$NB_USER/envs/py36/bin/activate && \
 
 # Installing jupyter-widgets
 RUN /bin/bash -cl 'source /home/$NB_USER/envs/py36/bin/activate && \
-                   pip install ipympl==0.5.6 && \
-                   pip install hdfviewer==0.11.0 && \
                    jupyter labextension install @jupyter-widgets/jupyterlab-manager && \
                    jupyter labextension install jupyter-matplotlib'
 

--- a/resen-core/resources/helpers/setup_py27_env.sh
+++ b/resen-core/resources/helpers/setup_py27_env.sh
@@ -41,6 +41,7 @@ pip install -U paramiko==2.4.2 \
                aacgmv2==2.5.2 \
                pymap3d==1.8.1 \
                astropy==2.0.14 \
+               ipympl==0.5.6 \
                # sunpy==0.9.10
 
 # Custom pip installation for any package that needs it

--- a/resen-core/resources/helpers/setup_py36_env.sh
+++ b/resen-core/resources/helpers/setup_py36_env.sh
@@ -44,7 +44,7 @@ pip install -U jupyterhub==1.0.0 \
                astropy==3.2.1 \
                plasmapy==0.3.1 \
                pydarn==1.0.0.1 \
-               viresclient==0.6.1
+               viresclient==0.6.1 \
                ipympl==0.5.6 \
                hdfviewer==0.11.0 \
                # sunpy==1.1.3

--- a/resen-core/resources/helpers/setup_py36_env.sh
+++ b/resen-core/resources/helpers/setup_py36_env.sh
@@ -45,6 +45,8 @@ pip install -U jupyterhub==1.0.0 \
                plasmapy==0.3.1 \
                pydarn==1.0.0.1 \
                viresclient==0.6.1
+               ipympl==0.5.6 \
+               hdfviewer==0.11.0 \
                # sunpy==1.1.3
 
 # Custom pip installation for any package that needs it


### PR DESCRIPTION
This is a quick fix to make widgets available also to the py27 environment.
hdfviewer is put only in py36. its not supported in py27.