### PR TITLE
[ENH]: Include AMGeO

### DIFF
--- a/resen-core/Dockerfile
+++ b/resen-core/Dockerfile
@@ -83,6 +83,11 @@ RUN /bin/bash -c 'bash setup_basemap.sh && rm setup_basemap.sh'
 COPY resources/helpers/setup_pyglow.sh .
 RUN /bin/bash -cl 'bash setup_pyglow.sh && rm setup_pyglow.sh'
 
+# Install AMGeO
+COPY resources/helpers/AMGeO-2.0.0beta.zip .
+COPY resources/helpers/setup_amgeo.sh .
+RUN /bin/bash -cl 'bash setup_amgeo.sh && rm setup_amgeo.sh'
+
 # Install citationhelper
 USER root
 COPY resources/pkg_citations.json /home/$NB_USER/cache/

--- a/resen-core/resources/helpers/setup_amgeo.sh
+++ b/resen-core/resources/helpers/setup_amgeo.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#######################################################################################
+#
+#    A helper script for installing AMGeO
+#
+#    Assumes you have a py38 python virtual environments
+#
+#######################################################################################
+
+echo "**** Installing AMGeO ****"
+
+AMGEO_INSTALL_DIR=${HOME}/bin/amgeo
+AMGEO_ARCHIVE=${HOME}/AMGeO-2.0.0beta.zip
+
+# extract source and enter directory
+mkdir -p ${AMGEO_INSTALL_DIR}
+cd ${AMGEO_INSTALL_DIR}
+unzip ${AMGEO_ARCHIVE} -d .
+cd AMGeO-2.0.0beta
+
+# install Python dependencies
+source ${HOME}/envs/py38/bin/activate
+
+pip install -e git+git://github.com/lkilcommons/geospacepy-lite.git#egg=geospacepy
+pip install -e git+git://github.com/lkilcommons/OvationPyme.git#egg=ovationpyme
+pip install -e git+git://github.com/lkilcommons/apex-python.git#egg=apexpython
+pip install -e git+git://github.com/lkilcommons/nasaomnireader.git#egg=nasaomnireader
+
+# install AMGeO
+python setup.py develop
+
+deactivate
+
+# clean up archive
+rm -r $AMGEO_ARCHIVE
+
+# Now modify location where output files are saved by default
+sed -i 's/    outdir = os.path.expanduser("~\/amgeo_v2_output")/    outdir = os.path.expanduser("~\/work\/amgeo_v2_output")/g' ${AMGEO_INSTALL_DIR}/AMGeO-2.0.0beta/AMGeO/driver_default.py


### PR DESCRIPTION
This PR adds AMGeO to resen-core.

## Using AMGeO

AMGeO is used by running it from the command line. Documentation is available here, after you register for an AMGeO account: https://amgeo.colorado.edu/protected/documentation/index.html.

Note that the `setup_amgeo.sh` script included in this PR changes the default output directory for AMGeO outputs from `~/amgeo_v2_output` to `~/work/amgeo_v2_output`.

### Configure

To configure AMGeO, navigate to `~/bin/amgeo/AMGeO-2.0.0beta` and then run:

    python configure.py

after which you will need to enter your AMGeO API token, which you get from the AMGeO website once you have registered: https://amgeo.colorado.edu. Then you enter your SuperMAG and AMPERE usernames, which you get when you register on their websites: https://supermag.jhuapl.edu/ and http://ampere.jhuapl.edu/.

### Running AMGeO
To run, we need to run the `driver_default.py` script in the `~/bin/amgeo/AMGeO-2.0.0beta/AMGeO` directory:

    python driver_default.py 2015 3 17 N --hour 3 --minute 2 --second 30

and the output from this will be placed inside of `~/work/amgeo_v2_output` by default.

### Notes

By default, datafiles used by AMGeO are downloaded and saved to `~/.local/share/AMGeO/` and `~/.local/share/nasaomnireader`.


## Testing this PR
1. Build the resen-core Dockerfile: `docker build -t testing .`
2. Test the resulting docker image by adding it to the available cores that resen can use. This is done by adding a `testing.json` file to `~/.config/resen/cores`.

Recommended format:

    [
        {"version":"latest","repo":"testing","org":"earthcubeingeo",
         "image_id":"ADD IMAGE HASH HERE",
         "repodigest":"sha256:b793f427f49aba05e38cb72b74789f2f5fd030b0be8a7639e48d24803b5da0a8",
         "envpath":"/home/jovyan/envs/py38"}
    ]

You can get the image hash with `docker images --no-trunc`.